### PR TITLE
Add types for withI18n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+## [1.0.1] - 2018-10-04
+
+### Added
+- Flow types for `withI18n`. ([@nickwaelkens](https://github.com/nickwaelkens) in [#2](https://github.com/teamleadercrm/i18n/pull/2))
+
+## [1.0.0] - 2018-08-30
+
+### Changed
+
+- Initial changelog

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamleader/i18n",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Teamleader i18n implementation",
   "author": "Teamleader <development@teamleader.eu>",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -159,4 +159,11 @@ class Provider extends React.PureComponent<Props, State> {
   }
 }
 
+export type Translate = (id: string, values?: {}) => string;
+export type FormatDate = (value: any, options?: {}) => string;
+export type WithI18nProps = {
+  translate: Translate,
+  formatDate: FormatDate
+};
+
 export { Provider, translate, formatDate, Translation, withI18n };


### PR DESCRIPTION
I have no idea how to type a HoC properly, but this also works:

```js
import { type WithI18nProps } from '@teamleader/i18n';

const Props = WithI18nProps & {
	foo: string,
	bar: number
}
```

Also added a `CHANGELOG.md` to be consistent with our other OSS projects.