### PR TITLE
Import locale data with a dynamic import

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,6 +5,7 @@
     "@babel/plugin-proposal-export-default-from",
     "@babel/plugin-proposal-export-namespace-from",
     "babel-plugin-transform-imports",
+    "@babel/plugin-syntax-dynamic-import",
     "transform-react-remove-prop-types"
   ],
   "presets": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [2.1.0] - 2019-03-08
+
+### Changed
+
+- Locale data from `react-intl` is now loaded with a dynamic import (`import()`). So the data will be loaded asynchronously now, instead of putting all the locale data into your bundle. This makes your bundle much smaller.
+
 ## [2.0.3] - 2019-02-27
 
 ### Security
@@ -15,6 +21,7 @@
 ## [2.0.2] - 2019-02-01
 
 ### Changed
+
 - Rename 'language' prop to 'locale'. (added in [#4](https://github.com/teamleadercrm/i18n/pull/4))
 - Default locale is now 'en-GB' instead of 'en'. (added in [#4](https://github.com/teamleadercrm/i18n/pull/4))
 - Support passing locale codes (e.g. 'nl-BE'). (added in [#4](https://github.com/teamleadercrm/i18n/pull/4))
@@ -22,6 +29,7 @@
 ## [1.0.1] - 2018-10-04
 
 ### Added
+
 - Flow types for `withI18n`. ([@nickwaelkens](https://github.com/nickwaelkens) in [#2](https://github.com/teamleadercrm/i18n/pull/2))
 
 ## [1.0.0] - 2018-08-30

--- a/package-lock.json
+++ b/package-lock.json
@@ -663,6 +663,15 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-syntax-dynamic-import": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
+      "integrity": "sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
     "@babel/plugin-syntax-export-default-from": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamleader/i18n",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamleader/i18n",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "Teamleader i18n implementation",
   "author": "Teamleader <development@teamleader.eu>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@babel/plugin-proposal-export-default-from": "^7.2.0",
     "@babel/plugin-proposal-export-namespace-from": "^7.2.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.3.4",
+    "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/preset-env": "^7.3.4",
     "@babel/preset-flow": "^7.0.0",
     "@babel/preset-react": "^7.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -138,7 +138,7 @@ class Provider extends React.PureComponent<Props, State> {
     return locale.split('-')[0];
   }
 
-  async getLocaleData(locale: string): Array<Object> {
+  async getLocaleData(locale: string): Promise<Array<Object>> {
     const language = this.localeToLanguage(locale);
 
     const module = await import(`react-intl/locale-data/${language}`);

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ class Provider extends React.PureComponent<Props, State> {
 
   async componentDidMount() {
     const locale = this.getUserLocale();
-    const localeData = this.getAllLocaleData();
+    const localeData = await this.getLocaleData(locale);
 
     addLocaleData(localeData);
     const translations = await this.fetchTranslations(locale);
@@ -138,20 +138,20 @@ class Provider extends React.PureComponent<Props, State> {
     return locale.split('-')[0];
   }
 
-  getAllLocaleData(): Array<Object> {
-    const languages = Object.keys(supportedLocales.reduce((languages, locale) => ({
-      ...languages,
-      [this.localeToLanguage(locale)]: true,
-    }), {}));
+  async getLocaleData(locale: string): Array<Object> {
+    const language = this.localeToLanguage(locale);
 
-    const localeData = languages.map(language => require(`react-intl/locale-data/${language}`));
+    const module = await import(`react-intl/locale-data/${language}`);
+    const localeData = module.default;
 
-    localeData.push({
-      locale: 'tlh',
-      parentLocale: 'en'
-    });
+    if (locale === 'tlh-KL') {
+      localeData.push({
+        locale: 'tlh',
+        parentLocale: 'en',
+      });
+    }
 
-    return localeData.reduce((allLocaleData, localeData) => allLocaleData.concat(localeData), []);
+    return localeData;
   }
 
   render() {
@@ -167,7 +167,7 @@ export type Translate = (id: string, values?: {}) => string;
 export type FormatDate = (value: any, options?: {}) => string;
 export type WithI18nProps = {
   translate: Translate,
-  formatDate: FormatDate
+  formatDate: FormatDate,
 };
 
 export { Provider, translate, formatDate, Translation, withI18n };


### PR DESCRIPTION
We were importing locale data from `react-intl` by using `require` inside a map. Due to this, Webpack actually imports the whole locale data directory, and thus also all the languages that we don't need. This adds more than 0.5mb to your package!

By using a dynamic import with `import()` solves this. Webpack will create separate chunks for all the locale data files, and load the one you really need on the fly. 