### PR TITLE
Add debug mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [2.2.0] - 2019-03-20
+
+### Added
+
+- Add a debug mode which, when enabled, will print the translation IDs instead of the actual translations. 
+
 ## [2.1.0] - 2019-03-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Wrap your app with the `Provider`.
 import { Provider as I18nProvider } from '@teamleader/i18n';
 
 const App = () => (
-  <I18nProvider namespace="domains.invoicing" path="/" language="en">
+  <I18nProvider namespace="domains.invoicing" path="/" locale="en">
     <TheRestOfYourApp />
   </I18nProvider>
 );
@@ -56,9 +56,9 @@ You can configure the `Provider` with a few props.
 
 The translation keys will be prefixed with the namespace. For example, if your namespace is `invoicing`, an example translation key would be `invoicing.myTranslationKey`.
 
-### `language` String (optional)
+### `locale` String (optional)
 
-The language that should be used. If you don't provide a language, it will try go get the language from the html element (`<html lang="en">`) and will fallback to english (`en`);
+The locale that should be used. If you don't provide a locale it will try to get it from the html element (`<html lang="en">`) and will fallback to english (`en`);
 
 ### `path`: String | Function (optional)
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ The path to the translation files. This can be either a string or a function. If
 
 Example with a string:
 
+### `debug`: Boolean (optional)
+
+When this is set to `true` the message IDs will be shown instead of the actual translations.
+
 ```js
 import { Provider as I18nProvider } from '@teamleader/i18n';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamleader/i18n",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamleader/i18n",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Teamleader i18n implementation",
   "author": "Teamleader <development@teamleader.eu>",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ type Props = {
   children: any,
   namespace: ?string,
   locale: ?string,
+  debug: ?boolean,
   path: string | (string => string),
 };
 
@@ -41,9 +42,11 @@ class Provider extends React.PureComponent<Props, State> {
 
   async componentDidMount() {
     const locale = this.getUserLocale();
+    const { debug } = this.props;
     const localeData = await this.getLocaleData(locale);
 
     addLocaleData(localeData);
+
     const translations = await this.fetchTranslations(locale);
 
     const component = React.createElement(IntlProvider, {
@@ -56,6 +59,10 @@ class Provider extends React.PureComponent<Props, State> {
         }
 
         const { intl } = element.getChildContext();
+
+        if (debug === true) {
+          intl.formatMessage = ({ id }) => id;
+        }
 
         const provideIntlContext = (
           Component: React.ComponentType<any>,


### PR DESCRIPTION
Add a debug mode which will show the translation ids instead of the actual translations. This will help non-developers to figure out which translations are used where.