### PR TITLE
Fix debug flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [6.0.0] - 2020-11-03
+
+### Fixed
+
+- Return translation ids when debug flag is set to true
+
 ## [5.0.0] - 2020-09-14
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamleader/i18n",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamleader/i18n",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "Teamleader i18n implementation",
   "author": "Teamleader <development@teamleader.eu>",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -87,7 +87,7 @@ class Provider extends React.PureComponent<Props, State> {
     formatNumber = intl.formatNumber;
     formatPlural = intl.formatPlural;
 
-    translate = (id: string, values: ?Object): string => intl.formatMessage({ id: this.getTranslationId(id) }, values);
+    translate = debug ? (id: string) => this.getTranslationId(id) : (id: string, values: ?Object): string => intl.formatMessage({ id: this.getTranslationId(id) }, values);
     Translation = props => <FormattedMessage {...props} id={props.id && this.getTranslationId(props.id)} />;
 
     this.setState({ intl });


### PR DESCRIPTION
I think the debug flag behaviour was accidentally removed some time ago. This PR adds it again so that when debug is set to true, the `translate` function will always simply return the translation key.