### PR TITLE
[LIG-2538] Add `de-CH` to supported locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [6.4.0] - 2022-05-25
+
+### Added
+
+- Added support for 'de-CH' locale
+
 ## [6.3.0] - 2022-05-11
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teamleader/i18n",
-  "version": "6.3.0",
+  "version": "6.4.0",
   "description": "Teamleader i18n implementation",
   "author": "Teamleader <development@teamleader.eu>",
   "license": "MIT",

--- a/src/supportedLocales.json
+++ b/src/supportedLocales.json
@@ -5,6 +5,7 @@
   "fr-FR",
   "en-GB",
   "de-DE",
+  "de-CH",
   "es-ES",
   "it-IT",
   "da-DK",


### PR DESCRIPTION
### Description
Included `de-CH` in supported locales file.

### Link to JIRA ticket
[LIG-2538](https://teamleader.atlassian.net/browse/LIG-2538)

[LIG-2538]: https://teamleader.atlassian.net/browse/LIG-2538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ